### PR TITLE
Mediagress plugin and FAQ text update, media page machina update

### DIFF
--- a/src/routes/media/[url_id]/+page.svelte
+++ b/src/routes/media/[url_id]/+page.svelte
@@ -43,13 +43,12 @@
           <img src={`/images/${factionLogo}`} height="32" alt={media.uploader_faction} />
         </a>
       </div>
-      <div class="title" style="color: var(--color-faction-{media.uploader_faction.toLowerCase() || 'unaligned'})">
-        <a href="/agent/{media.uploader_ign}">
-          {#if media.uploader_faction.toLowerCase() === 'machina'}
-            {zalgo(media.uploader_ign)}
-          {:else}
-            {media.uploader_ign}
-          {/if}
+    <div class="title" style="color: var(--color-faction-{media.uploader_faction.toLowerCase() || 'unaligned'})">
+    {#if media.uploader_faction.toLowerCase() === 'machina'}
+        {zalgo(media.uploader_ign)}
+    {:else}
+        <a href="/agent/{media.uploader_ign}">{media.uploader_ign}</a>
+    {/if}
         </a>
       </div>
     </div>

--- a/src/routes/media/upload/+page.svelte
+++ b/src/routes/media/upload/+page.svelte
@@ -14,7 +14,7 @@
         DOWNLOAD PLUGIN
     </a>
 
-    <p>If you still have the old plugin from mediagress.net installed, you can either update it or, if that is not possible, delete it before installing the new version from here. Updating the old plugin is not possible via the link above and has to be done via the add-on you use for plugins (Tampermonkey etc.). Future updates from here will be compatible after it.</p>
+    <p><b>Mediagress.net users:</b> If you still have the old plugin from mediagress.net installed, you should uninstall it before reinstalling the plugin from this site.</p>
 
     <h2>Usage</h2>
     <p><span style="color: #FFFFFF; text-decoration:underline">You need to have an active C.O.R.E. subscription</span> as the plugin needs to access your inventory from the Intel map.</p>
@@ -45,7 +45,7 @@
     <p class="question">What does the message "No new media has been found in your inventory." mean?</p>
     <p class="answer">Since your last upload, no new media has been found in your capsules compared to the last upload. If you have new media, make sure that it has been loaded into a capsule and try again in 5 minutes.</p>
     <p class="question">I have another question!</p>
-    <p class="answer">Join us in our Telegram group where we'll answer any questions that might come up <a href="https://t.me/Mediagress" target="_blank">with this link</a>.</p>
+    <p class="answer">Join us in our @Mediagress Telegram group where we'll answer any questions that might come up <a href="https://t.me/Mediagress" target="_blank">with the link in this channel</a>.</p>
 </div>
 
 <style>

--- a/static/mediagress.user.js
+++ b/static/mediagress.user.js
@@ -13,6 +13,9 @@
 // @grant none
 // ==/UserScript==
 
+// Changelog 1.0.1
+// Edited strings to make process of uploading clearer as well as giving a better understanding of errors when they happen
+
 // shout out to https://github.com/EisFrei/ and his Live Inventory plugin
 
 function wrapper(pluginInfo) {
@@ -155,10 +158,9 @@ function wrapper(pluginInfo) {
         });
         return;
       }
-      const responseText = await response.text
-      console.error(`Error making request to Mediagress: ${response.status} ${responseText}`);
-      alert(`There has been an error! Please contact the developers at https://t.me/Mediagress.\n\nError code: ${response.status}`);
-      //TODO: get ${responseText} to work; I am just a noob that gets by using google :(
+      console.error(`Error making request to Mediagress: ${response.status} ${await response.text()}`);
+      alert('Error :C please contact the developers at https://t.me/Mediagress');
+      //TODO: add response code and text to alert so users can just screenshot it instead of going into the console
       return;
     } catch (e) {
       alert('Failed to get inventory data from Intel. Try again in a moment');

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,7 @@
+User-agent: ADA
+User-agent: Omnivore
+Disallow: /
+
 User-Agent: *
 Allow: /
 Disallow: /_


### PR DESCRIPTION
Edited the text present in the Mediagress plugin and the FAQ site to make the process of uploading more clear as well as making Errors more understandable
--> god pls if you have spare time to figure out how to add the error response code and text to the error alert, I want to cry

Edited Media site so that if uploader faction is "Machina" no link to uploaded profile is generated
--> to be used if agents dont want to be known for any reason, change user to "unknown" and to faction "MACHINA" in the backend
--> atm uploader faction is determined at time of media upload and not the current Ingress.Plus faction

Edited robots.txt to protect against known NIA Artificial Intelligences