### PR TITLE
feat: add scroll-to-badge-category functionality via permalinks

### DIFF
--- a/src/lib/components/Category.svelte
+++ b/src/lib/components/Category.svelte
@@ -18,16 +18,26 @@
   $: rows = hasTiers
     ? Math.ceil(category.badges.length * tiers.length / badgesPerRow)
     : Math.ceil(category.badges.length / badgesPerRow)
+
+  const generateId = (str) =>
+    str
+      .replace(/[^\w\s]+/g, '-')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase()
+
+  const id = generateId(category.title)
 </script>
 
 <div style="--badge-size: {$badgeSize}px">
-  <h2>{category.title}</h2>
-  <section>
+  <section {id}>
+    <h2>{category.title}</h2>
     {#each { length: rows } as _, r}
       <div>
-      {#each { length: badgesPerRow } as _, c}
-        <Badge category={category} index={r * badgesPerRow + c} />
-      {/each}
+        {#each { length: badgesPerRow } as _, c}
+          <Badge {category} index={r * badgesPerRow + c} />
+        {/each}
       </div>
     {/each}
   </section>


### PR DESCRIPTION
Improves user navigation and makes it easier to share or reference specific badge categories using permalinks. e.g., `/ #statistic-badges` scrolls to the "Statistic Badges" section