### PR TITLE
fix: correct start\end datetime on events list page

### DIFF
--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -38,7 +38,7 @@
     const options = {
       filter: showAll ? "" : "homepage_hidden=false",
     }
-    const r = await pb.collection("game_events_list").getList(page, 1 * itemsPerPage, options)
+    const r = await pb.collection("game_events_list").getList(page, itemsPerPage, options)
     totalPages = r.totalPages
     totalItems = r.totalItems
     eventsList = r.items.map((e) => {
@@ -144,7 +144,7 @@
             {:else if e.start_time.isBefore(dayjs()) && e.end_time.isAfter(dayjs())}
               <strong>Ends <Time timestamp={e.end_time} relative live /></strong>
             {:else if e.end_time.isBefore(dayjs())}
-              <strong>Ended <Time timestamp={e.start_time} relative live /></strong>
+              <strong>Ended <Time timestamp={e.end_time} relative live /></strong>
             {/if}
             <small>(
               from <Time timestamp={e.start_time} format="MMMM D, YYYY [at] h:mm A" live />
@@ -165,7 +165,7 @@
 {/snippet}
 
 <div class="container">
-  {#each eventsList as event}
+  {#each eventsList as event (event.id)}
     {@render eventRow(event)}
   {/each}
   <div class="paginator">

--- a/src/routes/events/[event_id]/+page.svelte
+++ b/src/routes/events/[event_id]/+page.svelte
@@ -63,7 +63,7 @@
                  to <Time timestamp={event.end_time} format="MMMM D, YYYY [at] h:mm A" live />
              )</small>
          {:else if event.end_time.isBefore(dayjs())}
-             <strong>Ended <Time timestamp={event.start_time} relative live /></strong>
+             <strong>Ended <Time timestamp={event.end_time} relative live /></strong>
              <small>(
                  from <Time timestamp={event.start_time} format="MMMM D, YYYY [at] h:mm A" live />
                  to <Time timestamp={event.end_time} format="MMMM D, YYYY [at] h:mm A" live />


### PR DESCRIPTION
fixed the events list page. event's start\end datetimes now shows the correct values when switching pages