### PR TITLE
Drop Prime from Ingress Prime

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
         Ingress Plus is a fan site for the Niantic game <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://www.ingress.com">Ingress Prime</a
+            href="https://www.ingress.com">Ingress</a
         >. Users of this site can create a profile with badges they own in the game
         to share, submit Ingress media and check what Events are currently ongoing
 		or planned.

--- a/src/routes/attributions/+page.svelte
+++ b/src/routes/attributions/+page.svelte
@@ -9,7 +9,7 @@
     <ul>
        <li>
          This website features various images and other resources by <a href="https://www.nianticspatial.com/" target="_blank">Niantic Spatial, Inc.</a>,
-         such as sprites and textures of their game <a href="https://ingress.com/" target="_blank">Ingress Prime</a>
+         such as sprites and textures of their game <a href="https://ingress.com/" target="_blank">Ingress</a>
        </li>
        <li>
          This website features various Vectors and icons by <a href="https://www.svgrepo.com" target="_blank">SVG Repo</a>,

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -31,7 +31,7 @@
 
   <p>
     Ingress Plus is a non-commercial website that provides information and features
-    in relation to Ingress Prime. Ingress Prime itself is a mobile application
+    in relation to Ingress. Ingress itself is a mobile application
     created by Niantic Spatial, Inc. and is not connected to Ingress Plus in any
     way, be it technically or legally. Ingress Plus does not share any data with Niantic Spatial, Inc.
   </p>


### PR DESCRIPTION
With the Y13 event announcement it was announced that Ingress Prime would be renamed back to just Ingress, dropping the Prime. This PR removes the Prime from the three places it was mentioned