### PR TITLE
feat(feature-flags): gate Bug Report behind BUG_REPORTS_ENABLED

### DIFF
--- a/src/lib/featureFlags.js
+++ b/src/lib/featureFlags.js
@@ -1,5 +1,8 @@
 import { writable } from 'svelte/store'
 
 export const featureFlags = writable({
-  VERIFICATION_ENABLED: false
+  VERIFICATION_ENABLED: false,
+  BUG_REPORTS_ENABLED: false
 })
+
+export const featureFlagsLoaded = writable(false)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { SvelteToast } from '@zerodevx/svelte-toast'
   import { siteSettings } from '$lib/stores'
   import { pb } from '$lib/pocketbase'
-  import { featureFlags } from '$lib/featureFlags'
+  import { featureFlags, featureFlagsLoaded } from '$lib/featureFlags'
   import Header from '$lib/components/Header.svelte'
   import Footer from '$lib/components/Footer.svelte'
 
@@ -23,6 +23,8 @@
       featureFlags.set(Object.fromEntries(records.map(r => [r.name, r.enabled])))
     } catch (err) {
       console.error('Failed to load feature flags:', err)
+    } finally {
+      featureFlagsLoaded.set(true)
     }
 
     for (const key of Object.keys(window.localStorage)) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { resolve } from '$lib/utils'
+  import { featureFlags } from '$lib/featureFlags'
 </script>
 
 <svelte:head>
@@ -35,11 +36,13 @@
             <p><img src="/images/mediagress.png" alt="Mediagress" /> Mediagress</p>
         </div>
     </a>
-    <a class="hero hero-left" href={resolve('/bugs')}>
-        <div style="background-image: url('/images/homepage/cat_bug_tracker.jpg');">
-            <p><img src="/images/bugs.svg" alt="Bug Tracker" /> Bug Tracker</p>
-        </div>
-    </a>
+    {#if $featureFlags.BUG_REPORTS_ENABLED}
+        <a class="hero hero-left" href={resolve('/bugs')}>
+            <div style="background-image: url('/images/homepage/cat_bug_tracker.jpg');">
+                <p><img src="/images/bugs.svg" alt="Bug Tracker" /> Bug Tracker</p>
+            </div>
+        </a>
+    {/if}
     <a class="hero hero-right" href={resolve('/resources')}>
         <div style="background-image: url('/images/homepage/cat_resources.jpg');">
             <p><img src="/images/resources.svg" alt="Resources" /> Resources</p>

--- a/src/routes/bugs/+layout.svelte
+++ b/src/routes/bugs/+layout.svelte
@@ -1,5 +1,14 @@
 <script>
+    import { goto } from '$app/navigation'
+    import { resolve } from '$lib/utils'
+    import { browser } from '$app/environment'
+    import { featureFlags, featureFlagsLoaded } from '$lib/featureFlags'
+
     const { children } = $props()
+
+    $effect(() => {
+        if (browser && $featureFlagsLoaded && !$featureFlags.BUG_REPORTS_ENABLED) goto(resolve('/'))
+    })
 </script>
 
 <section>

--- a/src/routes/verify/+page.svelte
+++ b/src/routes/verify/+page.svelte
@@ -3,7 +3,7 @@
     import { resolve } from '$lib/utils'
     import { browser } from '$app/environment'
     import { authData } from '$lib/stores'
-    import { featureFlags } from '$lib/featureFlags'
+    import { featureFlags, featureFlagsLoaded } from '$lib/featureFlags'
 
     const username = $derived($authData?.baseModel?.username || 'NONE')
     const faction = $derived($authData?.baseModel?.faction || 'NOT SET')
@@ -11,7 +11,7 @@
     const userId = $derived($authData?.baseModel?.id || 'NONE')
 
     $effect(() => {
-        if (browser && !$featureFlags.VERIFICATION_ENABLED) goto(resolve('/'))
+        if (browser && $featureFlagsLoaded && !$featureFlags.VERIFICATION_ENABLED) goto(resolve('/'))
     })
 </script>
 


### PR DESCRIPTION
## Summary
- Adds a `BUG_REPORTS_ENABLED` flag guarding `/bugs`, `/bugs/new`, and `/bugs/[bug_id]` via a single redirect guard in `bugs/+layout.svelte`, and hides the homepage "Bug Tracker" tile when it's off - mirroring the existing `VERIFICATION_ENABLED` pattern.
- Fixes both redirect guards (`verify` and `bugs`) so they wait for the initial PocketBase feature-flags fetch to finish before deciding whether to redirect. Previously the store defaulted flags to `false` until the fetch resolved, so hitting a gated route directly or on reload could bounce you to the homepage even when the flag was enabled.

## Note
This branch is based on `feature/remote-feature-flags` (#103) and depends on it. **That PR needs to be reviewed/approved and merged first**, ideally before or alongside this one